### PR TITLE
Added global Snackbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <v-app dark>
+    <snackbar />
     <!-- Toolbar -->
     <v-toolbar app>
       <v-toolbar-title
@@ -42,6 +43,7 @@
 import jwt_decode from "jwt-decode";
 import { mapState, mapGetters, mapActions } from "vuex";
 import LoginDialog from "./components/LoginDialog";
+import Snackbar from "./components/Snackbar";
 
 export default {
   name: "App",
@@ -65,7 +67,8 @@ export default {
     })
   },
   components: {
-    LoginDialog
+    LoginDialog,
+    Snackbar
   },
   methods: {
     ...mapActions({

--- a/src/components/LoginDialog.vue
+++ b/src/components/LoginDialog.vue
@@ -29,12 +29,7 @@
             required
           ></v-text-field>
 
-          <v-btn
-            type="submit"
-            :disabled="!valid"
-            color="success"
-            @click="submitForm"
-          >
+          <v-btn type="submit" :disabled="!valid" color="success">
             Submit
           </v-btn>
         </v-form>
@@ -57,7 +52,8 @@ export default {
       passwordRules: [
         v => !!v || "Password is required",
         v =>
-          (v && v.length >= 5 && v.length <= 16 ) || "Length of password must be between 5 and 16"
+          (v && v.length >= 5 && v.length <= 16) ||
+          "Length of password must be between 5 and 16"
       ],
       emailRules: [
         v => !!v || "E-mail is required",

--- a/src/components/Snackbar.vue
+++ b/src/components/Snackbar.vue
@@ -1,0 +1,28 @@
+<template>
+  <v-snackbar v-model="show" :timeout="timeout" :color="color" top>
+    {{ text }}
+    <v-btn flat @click="close"> Close </v-btn>
+  </v-snackbar>
+</template>
+
+<script>
+import { mapState, mapActions } from "vuex";
+
+export default {
+  name: "snackbar",
+  computed: {
+    ...mapState("snackbar", ["text", "color", "timeout"]),
+    show: {
+      get() {
+        return this.$store.getters["snackbar/isShowing"];
+      },
+      set() {
+        this.close();
+      }
+    }
+  },
+  methods: {
+    ...mapActions("snackbar", ["close"])
+  }
+};
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import "./plugins/vuetify";
+import "./plugins/snackbar";
 import App from "./App.vue";
 import router from "./router";
 import "./registerServiceWorker";

--- a/src/plugins/snackbar.js
+++ b/src/plugins/snackbar.js
@@ -1,0 +1,13 @@
+import Vue from "vue";
+
+Vue.prototype.$ShowSuccessSnackbar = function(config) {
+  this.$store.dispatch("snackbar/ShowSuccessSnackbar", config);
+};
+
+Vue.prototype.$ShowErrorSnackbar = function(config) {
+  this.$store.dispatch("snackbar/ShowErrorSnackbar", config);
+};
+
+Vue.prototype.$ShowSnackbar = function(config) {
+  this.$store.dispatch("snackbar/ShowSnackbar", config);
+};

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,6 +3,7 @@ import Vuex from "vuex";
 import auth from "./modules/auth";
 import profile from "./modules/profile";
 import mangas from "./modules/manga";
+import snackbar from "./modules/snackbar";
 
 Vue.use(Vuex);
 
@@ -12,7 +13,8 @@ export default new Vuex.Store({
   modules: {
     auth,
     profile,
-    mangas
+    mangas,
+    snackbar
   },
   strict: debug
 });

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -28,7 +28,7 @@ const actions = {
       })
       .catch(err => console.log(err));
   },
-  login({ commit, state }, payload) {
+  login({ commit, state, dispatch }, payload) {
     loginPromise(payload)
       .then(res => {
         const { token } = res.data;
@@ -41,7 +41,13 @@ const actions = {
         });
         // commit("userLogin", decoded);
       })
-      .catch(err => console.log(err));
+      .catch(err =>
+        dispatch(
+          "snackbar/ShowErrorSnackbar",
+          { text: err.response.data.error },
+          { root: true }
+        )
+      );
   },
   logout({ commit, state }) {
     localStorage.removeItem("jwtToken");

--- a/src/store/modules/snackbar.js
+++ b/src/store/modules/snackbar.js
@@ -1,0 +1,50 @@
+const state = {
+  show: false,
+  text: "",
+  color: "success",
+  timeout: 3000
+};
+
+const getters = {
+  isShowing: state => {
+    return state.show;
+  }
+};
+
+const actions = {
+  ShowSnackbar({ commit }, config) {
+    commit("setSnackbar", { show: true, ...config });
+  },
+  ShowSuccessSnackbar({ commit }, config) {
+    commit("setSnackbar", { show: true, color: "success", ...config });
+  },
+  ShowErrorSnackbar({ commit }, config) {
+    commit("setSnackbar", { show: true, color: "error", ...config });
+  },
+  close({ commit }) {
+    commit("setSnackbar", { show: false });
+  }
+};
+
+const mutations = {
+  setSnackbar(state, { text, show, color, timeout }) {
+    if (text) {
+      state.text = text;
+    }
+    if (color) {
+      state.color = color;
+    }
+    if (timeout !== undefined) {
+      state.timeout = timeout;
+    }
+    state.show = show;
+  }
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+};


### PR DESCRIPTION
I added a snackbar component.

The snackbar can be called within a vue instance with : 

`this.$ShowSnackbar(config)`
`this.$ShowSuccessSnackbar(config)`
`this.$ShowErrorSnackbar(config)`

I added `ShowSuccessSnackbar` and `ShowErrorSnackbar` because it is the main usage of the snackbar.

config is an object with different properties: 

| name 	| type 	| default 	|
|---------	|------	|----------	|
| text 	| String 	| "" 	|
| color 	| String 	| "success" 	|
| timeout 	| Int 	| 3000 	|

Behind the scene thoses methods are calling vuex actions like this : 
`this.$store.dispatch("snackbar/ShowSnackbar", config);`

Closes #12 
